### PR TITLE
client: fix TLS socket timeout issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -292,8 +292,11 @@ func (mc *ModbusClient) Open() (err error) {
 			return
 		}
 
-		// create the TCP transport
-		mc.transport = newTCPTransport(sock, mc.conf.Timeout, mc.conf.Logger)
+		// create the TCP transport, wrapping the TLS socket in
+		// an adapter to work around write timeouts corrupting internal
+		// state (see https://pkg.go.dev/crypto/tls#Conn.SetWriteDeadline)
+		mc.transport = newTCPTransport(
+			newTLSSockWrapper(sock), mc.conf.Timeout, mc.conf.Logger)
 
 	case modbusTCPOverUDP:
 		// open a socket to the remote host (note: no actual connection is

--- a/tls_utils.go
+++ b/tls_utils.go
@@ -4,6 +4,9 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"os"
+	"time"
 )
 
 // LoadCertPool loads a certificate store from a file into a CertPool object.
@@ -31,6 +34,83 @@ func LoadCertPool(filePath string) (cp *x509.CertPool, err error) {
 		err = fmt.Errorf("%v: no certificate found", filePath)
 		return
 	}
+
+	return
+}
+
+// tlsSockWrapper wraps a TLS socket to work around odd error handling in
+// TLSConn on internal connection state corruption.
+// tlsSockWrapper implements the net.Conn interface to allow its
+// use by the modbus TCP transport.
+type tlsSockWrapper struct {
+	sock net.Conn
+}
+
+func newTLSSockWrapper(sock net.Conn) (tsw *tlsSockWrapper) {
+	tsw = &tlsSockWrapper{
+		sock: sock,
+	}
+
+	return
+}
+
+func (tsw *tlsSockWrapper) Read(buf []byte) (rlen int, err error) {
+	rlen, err = tsw.sock.Read(buf)
+
+	return
+}
+
+func (tsw *tlsSockWrapper) Write(buf []byte) (wlen int, err error) {
+	wlen, err = tsw.sock.Write(buf)
+
+	// since write timeouts corrupt the internal state of TLS sockets,
+	// any subsequent read/write operation will fail and return the same write
+	// timeout error (see https://pkg.go.dev/crypto/tls#Conn.SetWriteDeadline).
+	// this isn't all that helpful to clients, which may be tricked into
+	// retrying forever, treating timeout errors as transient.
+	// to avoid this, close the TLS socket after the first write timeout.
+	// this ensures that clients 1) get a timeout error on the first write timeout
+	// and 2) get an ErrNetClosing "use of closed network connection" on subsequent
+	// operations.
+	if err != nil && os.IsTimeout(err) {
+		tsw.sock.Close()
+	}
+
+	return
+}
+
+func (tsw *tlsSockWrapper) Close() (err error) {
+	err = tsw.sock.Close()
+
+	return
+}
+
+func (tsw *tlsSockWrapper) SetDeadline(deadline time.Time) (err error) {
+	err = tsw.sock.SetDeadline(deadline)
+
+	return
+}
+
+func (tsw *tlsSockWrapper) SetReadDeadline(deadline time.Time) (err error) {
+	err = tsw.sock.SetReadDeadline(deadline)
+
+	return
+}
+
+func (tsw *tlsSockWrapper) SetWriteDeadline(deadline time.Time) (err error) {
+	err = tsw.sock.SetWriteDeadline(deadline)
+
+	return
+}
+
+func (tsw *tlsSockWrapper) LocalAddr() (addr net.Addr) {
+	addr = tsw.sock.LocalAddr()
+
+	return
+}
+
+func (tsw *tlsSockWrapper) RemoteAddr() (addr net.Addr) {
+	addr = tsw.sock.RemoteAddr()
 
 	return
 }


### PR DESCRIPTION
This fixes a rare bug where modbus TCP over TLS connections would keep returning ErrTimeout following a write timeout error, regardless of actual connection state.
This is due to net.TLSConn's handling of TLS state corruption after a write timeout, which really should return a permanent error (e.g. "broken pipe") but doesn't for some reason.